### PR TITLE
Create gcp service account keys with terraform

### DIFF
--- a/sa-key-terraform/.gitignore
+++ b/sa-key-terraform/.gitignore
@@ -1,0 +1,15 @@
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+crash.log
+crash.*.log
+*.tfvars
+*.tfvars.json
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Sensitive key material
+service-account-key.json

--- a/sa-key-terraform/README.md
+++ b/sa-key-terraform/README.md
@@ -1,0 +1,49 @@
+# GCP Service Account + Key (Terraform)
+
+This Terraform config creates a Google Cloud service account and one key, and writes the key JSON to a local file with restrictive permissions.
+
+Important: Service account keys are embedded in Terraform state. Protect your state (use encrypted remote backend, locked access). Prefer Workload Identity over long‑lived keys whenever possible.
+
+## Prerequisites
+- Terraform >= 1.5
+- Authenticated to GCP (ADC). Options:
+  - `gcloud auth application-default login`, or
+  - Set `GOOGLE_APPLICATION_CREDENTIALS` to a credentials JSON path.
+
+## Usage
+```bash
+cd sa-key-terraform
+
+# Initialize providers
+terraform init
+
+# Create a service account and key
+terraform apply \
+  -var project_id="YOUR_PROJECT_ID" \
+  -var service_account_id="my-ci-bot" \
+  -var service_account_display_name="CI Bot" \
+  -var key_output_path="./service-account-key.json"
+
+# Show outputs (key path is sensitive)
+terraform output
+
+# The key JSON will be at the specified path with 0600 permissions
+ls -l ./service-account-key.json
+```
+
+## Rotating the key
+- Update `-var force_key_rotation_epoch=$(date +%s)` and re-apply, or
+- Taint the key and re-apply:
+  ```bash
+  terraform taint google_service_account_key.service_account_key
+  terraform apply
+  ```
+
+## Deleting only the key
+```bash
+terraform destroy -target google_service_account_key.service_account_key
+```
+
+## Notes
+- The service account remains if you only destroy the key. Destroy all to remove everything.
+- Consider binding roles to the service account separately (IAM role bindings are not included here).

--- a/sa-key-terraform/main.tf
+++ b/sa-key-terraform/main.tf
@@ -1,0 +1,27 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+resource "google_service_account" "service_account" {
+  account_id   = var.service_account_id
+  display_name = var.service_account_display_name
+  description  = var.service_account_description
+}
+
+resource "google_service_account_key" "service_account_key" {
+  service_account_id = google_service_account.service_account.name
+
+  # Changing this value forces key rotation by changing the resource ID via keepers
+  keepers = {
+    key_rotation_epoch = var.force_key_rotation_epoch
+  }
+}
+
+# Write the key JSON to a local file with restrictive permissions
+resource "local_sensitive_file" "service_account_key_json" {
+  filename             = var.key_output_path
+  content              = base64decode(google_service_account_key.service_account_key.private_key)
+  file_permission      = "0600"
+  directory_permission = "0700"
+}

--- a/sa-key-terraform/outputs.tf
+++ b/sa-key-terraform/outputs.tf
@@ -1,0 +1,20 @@
+output "service_account_email" {
+  description = "Email of the created service account"
+  value       = google_service_account.service_account.email
+}
+
+output "service_account_unique_id" {
+  description = "Unique ID of the created service account"
+  value       = google_service_account.service_account.unique_id
+}
+
+output "service_account_key_name" {
+  description = "Resource name of the created key"
+  value       = google_service_account_key.service_account_key.name
+}
+
+output "key_file_path" {
+  description = "Local filesystem path where the key JSON was written"
+  value       = local_sensitive_file.service_account_key_json.filename
+  sensitive   = true
+}

--- a/sa-key-terraform/variables.tf
+++ b/sa-key-terraform/variables.tf
@@ -1,0 +1,39 @@
+variable "project_id" {
+  description = "GCP project ID to create the service account in"
+  type        = string
+}
+
+variable "region" {
+  description = "Default region for the Google provider"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "service_account_id" {
+  description = "Service account ID (without domain), e.g. my-ci-bot"
+  type        = string
+}
+
+variable "service_account_display_name" {
+  description = "Display name for the service account"
+  type        = string
+  default     = "Terraform-created service account"
+}
+
+variable "service_account_description" {
+  description = "Description for the service account"
+  type        = string
+  default     = ""
+}
+
+variable "key_output_path" {
+  description = "Path on disk to write the service account key JSON"
+  type        = string
+  default     = "service-account-key.json"
+}
+
+variable "force_key_rotation_epoch" {
+  description = "Change this value (e.g. to a timestamp) to force key rotation"
+  type        = string
+  default     = ""
+}

--- a/sa-key-terraform/versions.tf
+++ b/sa-key-terraform/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.24.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 2.5.1"
+    }
+  }
+}


### PR DESCRIPTION
Add Terraform configuration to create a GCP service account and a service account key.

---
<a href="https://cursor.com/background-agent?bcId=bc-8e3e448f-f544-4366-a52f-caa840bac275">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8e3e448f-f544-4366-a52f-caa840bac275">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

